### PR TITLE
oneplus9: Inherit camera whatsoever.

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -95,7 +95,7 @@ PRODUCT_PACKAGES += \
     android.hardware.boot@1.1-service
 
 # Camera
-$(call inherit-product-if-exists, vendor/oplus/camera/oplus-camera.mk)
+$(call inherit-product, vendor/oplus/camera/oplus-camera.mk)
 
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.flash-autofocus.xml \


### PR DESCRIPTION
No need to inherit only if it exists because the changes done for OnePlus camera will break existing camera in the system. That would cause other third party apps to not work as some libs need to be patched for it to work, which is not in this case.